### PR TITLE
feat(api): add standalone image upload endpoint and simplify blog pos…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 .env
+/uploads

--- a/app.js
+++ b/app.js
@@ -26,6 +26,10 @@ connectDB();
 app.use(cors());
 app.use(bodyParser.json());
 
+// Configura o body-parser para aceitar requisições com tamanho máximo de 50mb
+app.use(bodyParser.json({ limit: '50mb' }));
+app.use(bodyParser.urlencoded({ limit: '50mb', extended: true }));
+
 
 // Configura o Express para servir arquivos estáticos da pasta 'uploads'
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));

--- a/controllers/blogController.js
+++ b/controllers/blogController.js
@@ -1,27 +1,27 @@
-import { uploadImages } from "../config/multerConfig.js";
+// import { uploadImages } from "../config/multerConfig.js";
 import { createPost, getPaginatedPosts } from "../services/blogService.js";
 import BlogPost from "../models/BlogPost.js";
 
 //Midleware para upload de imagens
-export const uploadImage = (req, res, next) => {
-  uploadImages(req, res, (err) => {
-    if (err) {
-      if (err.code === "LIMIT_FILE_SIZE") {
-        return res
-          .status(400)
-          .json({ message: "Arquivo muito grande (máx. 5MB)" });
-      }
-      if (err.message.includes("unexpected field")) {
-        return res.status(400).json({
-          message: `Campo inválido no upload. Use apenas 'thumb' e 'blogImg'`,
-          received: Object.keys(req.body).concat(Object.keys(req.files || {})),
-        });
-      }
-      return res.status(400).json({ message: err.message });
-    }
-    next();
-  });
-};
+// export const uploadImage = (req, res, next) => {
+//   uploadImages(req, res, (err) => {
+//     if (err) {
+//       if (err.code === "LIMIT_FILE_SIZE") {
+//         return res
+//           .status(400)
+//           .json({ message: "Arquivo muito grande (máx. 5MB)" });
+//       }
+//       if (err.message.includes("unexpected field")) {
+//         return res.status(400).json({
+//           message: `Campo inválido no upload. Use apenas 'thumb' e 'blogImg'`,
+//           received: Object.keys(req.body).concat(Object.keys(req.files || {})),
+//         });
+//       }
+//       return res.status(400).json({ message: err.message });
+//     }
+//     next();
+//   });
+// };
 
 export const createBlogPost = async (req, res) => {
   try {

--- a/routes/blogRoutes.js
+++ b/routes/blogRoutes.js
@@ -4,16 +4,16 @@ import {
   getAllPosts,
   getPostById,
   updatePost,
-  uploadImage,
+  // uploadImage,
   deletePost,
   createBlogPost,
 } from "../controllers/blogController.js";
 
 // Rotas CRUD
-router.post("/posts", uploadImage, createBlogPost);
+router.post("/posts", createBlogPost);
 router.get("/posts", getAllPosts);
 router.get("/posts/:id", getPostById);
-router.put("/posts/:id", uploadImage, updatePost);
+router.put("/posts/:id", updatePost);
 router.delete("/posts/:id", deletePost);
 
 export default router;


### PR DESCRIPTION
…t upload flow

- Created a new POST /upload-image route using multer for standalone image uploads
- Removed uploadImages middleware from blog post create and update routes
- Updated multer configuration to store images in /public/uploads with size limits
- Adjusted .gitignore to exclude /uploads
- Ensured body-parser accepts large payloads (up to 50mb)